### PR TITLE
feat: allow trusting a cert digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ configuration file looks like this:
         "name": "less-favourite-vpn",
         "host": "two.vpn.com",
         "port": 10443,
-        "default": false
+        "default": false,
+        "cert": "hash of cert"
     }
 ]
 ```

--- a/vpn.sh
+++ b/vpn.sh
@@ -34,9 +34,11 @@ up() {
             echo "connecting to default vpn"
             host=$(jq -e -c 'map(select(.default == true)) | "\(.[0].host):\(.[0].port)"' $VPN_CFG_FILE | tr -d '"')
             name=$(jq -e -c 'map(select(.default == true)) | .[0].name' $VPN_CFG_FILE | tr -d '"')
+            cert=$(jq -e -c 'map(select(.default == true)) | .[0].cert' $VPN_CFG_FILE | tr -d '"')
         else
             host=$(jq -e -c "map(select(.name == \"$1\")) | \"\(.[0].host):\(.[0].port)\"" $VPN_CFG_FILE | tr -d '"')
             name=$(jq -e -c "map(select(.name == \"$1\")) | .[0].name" $VPN_CFG_FILE | tr -d '"')
+            cert=$(jq -e -c "map(select(.name == \"$1\")) | .[0].cert" $VPN_CFG_FILE | tr -d '"')
             if [[ $? == 1 ]]
             then
                 echo "could not find host $1, check the ~/.vpn config file"
@@ -46,7 +48,11 @@ up() {
         echo "connecting to $name"
         echo $name > $VPN_NAME_FILE
         COOKIE=$(openfortivpn-webview $host)
-        sudo -b openfortivpn --cookie=$COOKIE $host
+        if [ $cert = "null" ]; then
+          sudo -b openfortivpn --cookie=$COOKIE $host
+        else
+          sudo -b openfortivpn --cookie=$COOKIE $host --trusted-cert $cert
+        fi
     else
         echo "vpn already connected"
     fi


### PR DESCRIPTION
Ran into this error earlier:
```
ERROR:  Gateway certificate validation failed, and the certificate digest is not in the local whitelist. If you trust it, rerun with:
ERROR:      --trusted-cert 22edd86cce8a4d46591f0f8b63f388b98d9abc8a2eb4cd684c85172be066bac2
ERROR:  or add this line to your configuration file:
ERROR:      trusted-cert = 22edd86cce8a4d46591f0f8b63f388b98d9abc8a2eb4cd684c85172be066bac2
ERROR:  Gateway certificate:
ERROR:      subject:
...
ERROR:      issuer:
...
ERROR:      sha256 digest:
ERROR:          22edd86cce8a4d46591f0f8b63f388b98d9abc8a2eb4cd684c85172be066bac2
```

This patch is to allow passing ``--trusted-cert <hash>`` to the program which might not be the best solution was enough to get me up and running again today.